### PR TITLE
Remove return True from auth_func in favor of pass

### DIFF
--- a/server.py
+++ b/server.py
@@ -52,7 +52,7 @@ def load_user(payload):
 # Flask-Restless API  =========================================================
 @jwt_required()
 def auth_func(**kw):
-    return True
+    pass
 
 
 apimanager = APIManager(app, flask_sqlalchemy_db=db)


### PR DESCRIPTION
This function always returned True (1) and therefore calls to a protected resource at /api/v1/resource/{whatever_id} always went to /api/v1/resource/1 regardless of the ID.

http://flask-restless.readthedocs.org/en/latest/customizing.html#request-preprocessors-and-postprocessors

> The preprocessors and postprocessors for each type of request accept different arguments. Most of them should have no return value (more specifically, any returned value is ignored). The return value from each of the GET_SINGLE, PATCH_SINGLE, and DELETE_SINGLE preprocessors is interpreted as a value with which to replace instance_id, the variable containing the value of the primary key of the requested instance of the model. For example, if a request for :http:get:`/api/person/1` encounters a preprocessor (for GET_SINGLE) that returns the integer 8, Flask-Restless will continue to process the request as if it had received :http:get:`/api/person/8`. (If multiple preprocessors are specified for a single HTTP method and each one has a return value, Flask-Restless will only remember the value returned by the last preprocessor function.)
